### PR TITLE
Add flag to curl invocation to follow redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ need for another user account. Simply put, it allows me to log in like normal.
 
 Run [this][install] in the terminal.
 
-    curl https://raw.github.com/jridgewell/Unlock/master/install.sh | bash
+    curl -L https://raw.github.com/jridgewell/Unlock/master/install.sh | bash
 
 - You will be asked for your login password.
 - Follow the prompts
@@ -44,7 +44,7 @@ Run [this][install] in the terminal.
 Run [this][uninstall] in the terminal (you'll be asked for your login password)
 to remove all traces from the system.
 
-    curl https://raw.github.com/jridgewell/Unlock/master/uninstall.sh | bash
+    curl -L https://raw.github.com/jridgewell/Unlock/master/uninstall.sh | bash
 
 
 ## Q&A


### PR DESCRIPTION
Because GitHub has evidently changed the location of the referenced files and is redirecting to them with a 301 Moved Permanently, the command lines as-is will not work today. Adding the -L flag to follow redirects seems to do the trick, though you may want to consider also replacing the URLs with their new canonical values.

Thanks for the great tool!
